### PR TITLE
Feature/install redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "next": "^9.2.1",
+    "next-redux-wrapper": "^4.0.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/jest": "^25.1.2",
     "@types/node": "^13.7.1",
     "@types/react": "^16.9.19",
+    "@types/react-redux": "^7.1.7",
     "@types/styled-components": "^4.4.3",
     "@typescript-eslint/eslint-plugin": "^2.19.2",
     "@typescript-eslint/parser": "^2.19.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "next": "^9.2.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-redux": "^7.1.3",
+    "redux": "^4.0.5",
     "styled-components": "^5.0.1"
   },
   "devDependencies": {
@@ -35,6 +37,7 @@
     "eslint-plugin-react": "^7.18.3",
     "jest": "^25.1.0",
     "prettier": "^1.19.1",
+    "redux-devtools-extension": "^2.13.8",
     "typescript": "^3.7.5"
   }
 }

--- a/src/frameworks/next/pages/_app.tsx
+++ b/src/frameworks/next/pages/_app.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import withRedux from 'next-redux-wrapper';
+
+import { store } from '../store';
+
+const MyApp = (props): JSX.Element => {
+    const { Component, pageProps, store } = props;
+    return (
+        <Provider store={store}>
+            <Component {...pageProps} />
+        </Provider>
+    );
+};
+
+export default withRedux(store)(MyApp);

--- a/src/frameworks/next/pages/index.tsx
+++ b/src/frameworks/next/pages/index.tsx
@@ -1,7 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
+import { useDispatch, useSelector } from 'react-redux';
+import { sayHelloToNext } from '../store/init';
+import { TAppStore } from '../store';
 
-const App: React.FC = () => <Wrapper>Hello Next.tsx</Wrapper>;
+const App: React.FC = () => {
+    const dispatch = useDispatch();
+    const { name } = useSelector((state: TAppStore) => state.init);
+
+    useEffect(() => {
+        dispatch(sayHelloToNext());
+    }, []);
+
+    return <Wrapper>Hello {name}</Wrapper>;
+};
 
 const Wrapper = styled.div`
     font-weight: bold;

--- a/src/frameworks/next/store/index.ts
+++ b/src/frameworks/next/store/index.ts
@@ -1,5 +1,6 @@
 import { createStore, applyMiddleware, combineReducers, StoreEnhancer, Store } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
+import { reducer as init, InitStore } from './init';
 
 const bindMiddleware = (middleware): StoreEnhancer => {
     if (process.env.NODE_ENV !== 'production') {
@@ -9,7 +10,11 @@ const bindMiddleware = (middleware): StoreEnhancer => {
     }
 };
 
-export const appReducer = combineReducers({});
+export interface TAppStore {
+    init: InitStore;
+}
+
+export const appReducer = combineReducers({ init });
 
 export const store = (): Store => {
     return createStore(appReducer, bindMiddleware([]));

--- a/src/frameworks/next/store/index.ts
+++ b/src/frameworks/next/store/index.ts
@@ -1,0 +1,16 @@
+import { createStore, applyMiddleware, combineReducers, StoreEnhancer, Store } from 'redux';
+import { composeWithDevTools } from 'redux-devtools-extension';
+
+const bindMiddleware = (middleware): StoreEnhancer => {
+    if (process.env.NODE_ENV !== 'production') {
+        return composeWithDevTools(applyMiddleware(...middleware));
+    } else {
+        return applyMiddleware(...middleware);
+    }
+};
+
+export const appReducer = combineReducers({});
+
+export const store = (): Store => {
+    return createStore(appReducer, bindMiddleware([]));
+};

--- a/src/frameworks/next/store/init/actions.ts
+++ b/src/frameworks/next/store/init/actions.ts
@@ -1,0 +1,10 @@
+import { InitActionTypes, SAY_HELLO_TO_REDUX } from './types';
+
+export const sayHelloToNext = (): InitActionTypes => {
+    return {
+        type: SAY_HELLO_TO_REDUX,
+        payload: {
+            name: 'Next.tsx with Redux',
+        },
+    };
+};

--- a/src/frameworks/next/store/init/index.ts
+++ b/src/frameworks/next/store/init/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './actions';
+export * from './reducer';

--- a/src/frameworks/next/store/init/reducer.ts
+++ b/src/frameworks/next/store/init/reducer.ts
@@ -1,0 +1,20 @@
+import { Reducer } from 'redux';
+
+import { InitStore, InitActionTypes, SAY_HELLO_TO_REDUX } from './types';
+import {} from './actions';
+
+const initialState: InitStore = {
+    name: '',
+};
+
+export const reducer: Reducer<InitStore, InitActionTypes> = (state = initialState, action) => {
+    switch (action.type) {
+        case SAY_HELLO_TO_REDUX: {
+            const { name } = action.payload;
+            return { ...state, name };
+        }
+        default: {
+            return { ...state };
+        }
+    }
+};

--- a/src/frameworks/next/store/init/types.ts
+++ b/src/frameworks/next/store/init/types.ts
@@ -1,0 +1,14 @@
+export const SAY_HELLO_TO_REDUX = 'IT/SAY_HELLO_TO_REDUX';
+
+interface SayHelloToRedux {
+    type: typeof SAY_HELLO_TO_REDUX;
+    payload: {
+        name: string;
+    };
+}
+
+export type InitActionTypes = SayHelloToRedux;
+
+export interface InitStore {
+    name: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9421,7 +9421,7 @@ react-is@16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -9451,6 +9451,18 @@ react-popper@^1.3.6:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-redux@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.3.tgz#717a3d7bbe3a1b2d535c94885ce04cdc5a33fc79"
+  integrity sha512-uI1wca+ECG9RoVkWQFF4jDMqmaw0/qnvaSvOoL/GA4dNxf6LoV8sUAcNDvE5NWKs4hFpn0t6wswNQnY3f7HT3w==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react-sizeme@^2.6.7:
   version "2.6.12"
@@ -9577,6 +9589,19 @@ recursive-readdir@2.2.2:
   integrity sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==
   dependencies:
     minimatch "3.0.4"
+
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
+
+redux@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
+  integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==
+  dependencies:
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -10753,6 +10778,11 @@ svgo@^1.2.2:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
+
+symbol-observable@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7799,6 +7799,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
+next-redux-wrapper@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-4.0.1.tgz#70f2d83b5bd0fb07ec19e6e70bea6b179d295fd7"
+  integrity sha512-aj9s4VT062hvrU8k2OQevf6iffHSIXpDXtIA8xbLzfpP94h3w7vZCmAJmbmfq3rXignqJT3KG44GODwsCQmdsA==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,7 +1909,7 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
   integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
 
-"@types/hoist-non-react-statics@*":
+"@types/hoist-non-react-statics@*", "@types/hoist-non-react-statics@^3.3.0":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
   integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
@@ -1994,6 +1994,16 @@
   integrity sha512-nScK4ScGibADx4fEjkM9ps1q3ij7OAbkaINJ/jwBNrwQg19RPB1fHTrh7r4KBsHn+ile/j2KPwyQm/H7DbConQ==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.7":
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.7.tgz#12a0c529aba660696947384a059c5c6e08185c7a"
+  integrity sha512-U+WrzeFfI83+evZE2dkZ/oF/1vjIYgqrb5dGgedkqVV8HEfDFujNgWCwHL89TDuWKb47U0nTBT6PLGq4IIogWg==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react-syntax-highlighter@11.0.2":
   version "11.0.2"
@@ -9600,7 +9610,7 @@ redux-devtools-extension@^2.13.8:
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
   integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
 
-redux@^4.0.5:
+redux@^4.0.0, redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"
   integrity sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==


### PR DESCRIPTION
## 목적
-  단일 데이터 플로우로 웹 앱 전반과 관련된 상태관리

## 변경 사항
- `Redux` 설치
- `SSR`할때 서버와 클라이언트의 `Store`상태가 다른 이슈를 해결하기 위해 `next-redux-wrapper` 설치

## TODO
-

## Reference
- [Next.js에서 SSR 하는 방법 From Next.js Docs](https://nextjs.org/docs/basic-features/pages#server-side-rendering)
- [next-redux-wrapper 깃헙 레퍼지토리](https://github.com/kirill-konshin/next-redux-wrapper)
- [Next.js에서 next-redux-wrapper 사용한 예제 from Next.js Github Repository](https://github.com/zeit/next.js/tree/canary/examples/with-redux-wrapper)