### PR TITLE
Feature/deploy with docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+.github/
+__tests__/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3'
+
+services:
+  next-staging:
+    build: 
+      context: .
+      dockerfile: ./docker/next-staging.Dockerfile
+    expose:
+      - 8080
+    ports:
+      - 8080:80
+    command: yarn run start
+
+
+  storybok:
+    build:
+      context: .
+      dockerfile: ./docker/storybook.Dockerfile
+    expose: 
+      - 8081
+    ports:
+      - 8081:8081
+    command: npx http-server .dist -p 8081 --silent

--- a/docker/next-staging.Dockerfile
+++ b/docker/next-staging.Dockerfile
@@ -1,9 +1,8 @@
 FROM node:13.2.0 as builder
 
 # 작업 폴더를 만들고 npm 설치
-RUN mkdir /usr/src/app
-WORKDIR /usr/src/app
+RUN mkdir /usr/next-staging
+WORKDIR /usr/next-staging
 COPY . .
 RUN yarn install
 RUN yarn run build
-CMD yarn run start

--- a/docker/staging.Dockerfile
+++ b/docker/staging.Dockerfile
@@ -1,0 +1,9 @@
+FROM node:13.2.0 as builder
+
+# 작업 폴더를 만들고 npm 설치
+RUN mkdir /usr/src/app
+WORKDIR /usr/src/app
+COPY . .
+RUN yarn install
+RUN yarn run build
+CMD yarn run start

--- a/docker/storybook.Dockerfile
+++ b/docker/storybook.Dockerfile
@@ -1,0 +1,7 @@
+FROM node:13.2.0 as builder
+
+RUN mkdir /usr/storybook
+WORKDIR /usr/storybook
+COPY . .
+RUN yarn install
+RUN yarn run build-storybook -c .storybook -o .dist --loglevel error --quiet

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "next ./src/frameworks/next",
     "build": "next build ./src/frameworks/next",
-    "start": "next start ./src/frameworks/next",
+    "start": "next start ./src/frameworks/next -p 80",
     "storybook": "start-storybook -p 6006 -c .storybook",
     "test": "jest"
   },

--- a/src/frameworks/next/store/index.ts
+++ b/src/frameworks/next/store/index.ts
@@ -3,11 +3,7 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import { reducer as init, InitStore } from './init';
 
 const bindMiddleware = (middleware): StoreEnhancer => {
-    if (process.env.NODE_ENV !== 'production') {
-        return composeWithDevTools(applyMiddleware(...middleware));
-    } else {
-        return applyMiddleware(...middleware);
-    }
+    return composeWithDevTools(applyMiddleware(...middleware));
 };
 
 export interface TAppStore {


### PR DESCRIPTION
## 목적
- 하나의 도메인에 프레임워크 별로 따로 빌드 및 서로 다른 포트에 배포

## 변경 사항
- 빌드에 필요없는 파일 `docker`에서 무시하게 설정
- 프레임워크 별로 `Dockerfile` 따로 생성
- 여러개 `Dockerfile`을 관리하기 위해 `docker-compose.yml` 파일 추가 
- `Redux-devtool`을 배포 환경에 상관없이 사용

## TODO
- `Readme.md` 작성

## Reference
- [Redux-Devtools를 Production 환경에서 사용해야하는 이유 from Medium](https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f)
- [Docker Compse를 활용해서 개발환경 구성하기 from 44BITS](https://www.44bits.io/ko/post/almost-perfect-development-environment-with-docker-and-docker-compose)